### PR TITLE
Skip fields with variations and substitutions

### DIFF
--- a/Sources/AITranslate.swift
+++ b/Sources/AITranslate.swift
@@ -125,14 +125,20 @@ struct AITranslate: AsyncParsableCommand {
       // - the `force` flag has been specified.
       guard force ||
               localizationEntries[lang] == nil ||
-              localizationEntries[lang]?.stringUnit.value.isEmpty == true
+              localizationEntries[lang]?.stringUnit?.value.isEmpty == true,
+
+            // skip the ones with variations since they are not supported.
+            localizationEntries[lang]?.variations == nil,
+
+            // skip the ones with substitutions since they are not supported.
+            localizationEntries[lang]?.substitutions == nil
       else {
         continue
       }
 
       // The source text can either be the key or an explicit value in the `localizations`
       // dictionary keyed by `sourceLanguage`.
-      let sourceText = localizationEntries[sourceLanguage]?.stringUnit.value ?? key
+      let sourceText = localizationEntries[sourceLanguage]?.stringUnit?.value ?? key
 
       let result = try await performTranslation(
         sourceText,
@@ -154,7 +160,7 @@ struct AITranslate: AsyncParsableCommand {
 
   func save(_ dict: StringsDict) throws {
     let encoder = JSONEncoder()
-    encoder.outputFormatting = .prettyPrinted
+    encoder.outputFormatting = [.sortedKeys, .prettyPrinted, .withoutEscapingSlashes]
     let data = try encoder.encode(dict)
 
     try backupInputFileIfNecessary()

--- a/Sources/StringsDict.swift
+++ b/Sources/StringsDict.swift
@@ -14,25 +14,63 @@ class StringsDict: Codable {
 }
 
 class LocalizationGroup: Codable {
-  let comment: String?
-  let extractionState: String?
+  var comment: String?
+  var extractionState: String?
   var localizations: [String: LocalizationUnit]?
 }
 
 class LocalizationUnit: Codable {
-  let stringUnit: StringUnit
+  var stringUnit: StringUnit?
+  var variations: VariationsUnit?
+  var substitutions: [String: SubstitutionsUnit]?
 
-  init(stringUnit: StringUnit) {
+  init(stringUnit: StringUnit?, variations: VariationsUnit? = nil, substitutions: [String: SubstitutionsUnit]? = nil) {
     self.stringUnit = stringUnit
+    self.variations = variations
+    self.substitutions = substitutions
   }
 }
 
 class StringUnit: Codable {
-  let state: String
-  let value: String
+  var state: String
+  var value: String
 
   init(state: String, value: String) {
     self.state = state
     self.value = value
   }
+}
+
+class VariationsUnit: Codable {
+  var plural: PluralVariation?
+  var device: DeviceVariation?
+}
+
+class SubstitutionsUnit: Codable {
+  var formatSpecifier: String
+  var variations: VariationsUnit
+}
+
+class PluralVariation: Codable {
+  var zero: VariationStringUnit?
+  var one: VariationStringUnit?
+  var two: VariationStringUnit?
+  var few: VariationStringUnit?
+  var many: VariationStringUnit?
+  var other: VariationStringUnit?
+}
+
+class DeviceVariation: Codable {
+  var appletv: VariationStringUnit?
+  var applevision: VariationStringUnit?
+  var applewatch: VariationStringUnit?
+  var ipad: VariationStringUnit?
+  var iphone: VariationStringUnit?
+  var ipod: VariationStringUnit?
+  var mac: VariationStringUnit?
+  var other: VariationStringUnit?
+}
+
+class VariationStringUnit: Codable {
+  var stringUnit: StringUnit
 }


### PR DESCRIPTION
Skip fields with variations and substitutions since these keys are not supported.
Also added `.sortedKeys`, and `.withoutEscapingSlashes` to the `JSONEncoder()` to match the behavior of xcode.

I ran these on two of my project with strings catalogs that are already translated and it now produce the exact same string catalog files without messing up existing fields or orders.