### PR TITLE
Batch translation API calls (~20x fewer requests)

### DIFF
--- a/Sources/AITranslate/AITranslateCommand.swift
+++ b/Sources/AITranslate/AITranslateCommand.swift
@@ -9,6 +9,11 @@ import ArgumentParser
 import OpenAI
 import Foundation
 import AITranslateLib
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
 @main
 struct AITranslateCommand: AsyncParsableCommand {
@@ -24,7 +29,7 @@ struct AITranslateCommand: AsyncParsableCommand {
 
   @Option(
     name: .shortAndLong,
-    help: ArgumentHelp("A comma separated list of language codes (must match the language codes used by xcstrings)"), 
+    help: ArgumentHelp("A comma separated list of language codes (must match the language codes used by xcstrings)"),
     transform: AITranslateCommand.gatherLanguages(from:)
   )
   var languages: [String]
@@ -50,14 +55,26 @@ struct AITranslateCommand: AsyncParsableCommand {
   )
   var force: Bool = false
 
+  @Flag(
+    name: .long,
+    help: ArgumentHelp("Disable the rich terminal UI and use simple text output instead.")
+  )
+  var noTui: Bool = false
+
   mutating func run() async throws {
+    let useRichUI = !noTui && isatty(STDERR_FILENO) != 0
+    let reporter: ProgressReporter = useRichUI
+      ? RichProgressReporter(verbose: verbose)
+      : SimpleProgressReporter()
+
     try await AITranslate(
       inputFile: inputFile,
       languages: languages,
       openAIKey: openAIKey,
       verbose: verbose,
       skipBackup: skipBackup,
-      force: force
+      force: force,
+      reporter: reporter
     ).run()
   }
 }

--- a/Sources/AITranslateLib/AITranslate.swift
+++ b/Sources/AITranslateLib/AITranslate.swift
@@ -28,6 +28,7 @@ public final class AITranslate: @unchecked Sendable {
   let verbose: Bool
   let skipBackup: Bool
   let force: Bool
+  let reporter: ProgressReporter
 
   lazy var api: API = {
     let configuration = OpenAI.Configuration(
@@ -45,7 +46,8 @@ public final class AITranslate: @unchecked Sendable {
     openAIKey: String,
     verbose: Bool,
     skipBackup: Bool,
-    force: Bool
+    force: Bool,
+    reporter: ProgressReporter? = nil
   ) {
     self.inputFile = inputFile
     self.languages = languages
@@ -53,6 +55,7 @@ public final class AITranslate: @unchecked Sendable {
     self.verbose = verbose
     self.skipBackup = skipBackup
     self.force = force
+    self.reporter = reporter ?? SimpleProgressReporter()
   }
 
   public func run() async throws {
@@ -62,10 +65,19 @@ public final class AITranslate: @unchecked Sendable {
         from: try Data(contentsOf: inputFile)
       )
 
-      let totalEntries = catalog.strings.count
-      let start = Date()
-      var previousPercentage: Int = -1
-      var entriesCompleted = 0
+      // Compute per-entry translation count: for each entry, how many languages need translating.
+      var totalTranslations = 0
+      for entry in catalog.strings {
+        for lang in languages {
+          let unit = entry.value.localizations?[lang]
+          if let unit, unit.hasTranslation, force == false {
+            continue
+          }
+          totalTranslations += 1
+        }
+      }
+
+      await reporter.translationStarted(totalEntries: totalTranslations, languages: languages)
 
       // Force lazy initialization before concurrent access.
       _ = self.api
@@ -79,13 +91,6 @@ public final class AITranslate: @unchecked Sendable {
           if inFlight >= maxConcurrent {
             try await group.next()
             inFlight -= 1
-            entriesCompleted += 1
-
-            let percentageProcessed = Int(Double(entriesCompleted) / Double(totalEntries) * 100)
-            if percentageProcessed != previousPercentage, percentageProcessed % 10 == 0 {
-              print("[⏳] \(percentageProcessed)%")
-              previousPercentage = percentageProcessed
-            }
           }
 
           group.addTask {
@@ -98,25 +103,13 @@ public final class AITranslate: @unchecked Sendable {
           inFlight += 1
         }
 
-        while let _ = try await group.next() {
-          entriesCompleted += 1
-          let percentageProcessed = Int(Double(entriesCompleted) / Double(totalEntries) * 100)
-          if percentageProcessed != previousPercentage, percentageProcessed % 10 == 0 {
-            print("[⏳] \(percentageProcessed)%")
-            previousPercentage = percentageProcessed
-          }
-        }
+        while let _ = try await group.next() {}
       }
 
       try save(catalog)
-
-      let formatter = DateComponentsFormatter()
-      formatter.allowedUnits = [.hour, .minute, .second]
-      formatter.unitsStyle = .full
-      let formattedString = formatter.string(from: Date().timeIntervalSince(start))!
-
-      print("[✅] 100% \n[⏰] Translations time: \(formattedString)")
+      await reporter.finished()
     } catch let error {
+      await reporter.finished()
       throw error
     }
   }
@@ -137,7 +130,7 @@ public final class AITranslate: @unchecked Sendable {
 
       // Skip the ones with variations/substitutions since they are not supported.
       if let unit, unit.isSupportedFormat == false {
-        print("[⚠️] Unsupported format in entry with key: \(key)")
+        await reporter.warning("Unsupported format in entry with key: \(key)")
         continue
       }
 
@@ -160,6 +153,9 @@ public final class AITranslate: @unchecked Sendable {
           value: result ?? ""
         )
       )
+
+      let success = result != nil
+      await reporter.translationCompleted(key: key, language: lang, success: success)
     }
   }
 
@@ -232,7 +228,7 @@ public final class AITranslate: @unchecked Sendable {
 
       return translation
     } catch let error {
-      print("[❌] Failed to translate \(text) into \(target)")
+      await reporter.error("Failed to translate \(text) into \(target)")
 
       if verbose {
         print("[💥]" + error.localizedDescription)

--- a/Sources/AITranslateLib/AITranslate.swift
+++ b/Sources/AITranslateLib/AITranslate.swift
@@ -193,7 +193,7 @@ public final class AITranslate: @unchecked Sendable {
       )
 
       if verbose, let translation {
-        print("[\(item.language)] " + item.sourceText + " -> " + translation)
+        await reporter.verboseLog("[\(item.language)] " + item.sourceText + " -> " + translation)
       }
 
       await reporter.translationCompleted(
@@ -393,7 +393,7 @@ public final class AITranslate: @unchecked Sendable {
       let translation = result.choices.first?.message.content ?? text
 
       if verbose {
-        print("[\(target)] " + text + " -> " + translation)
+        await reporter.verboseLog("[\(target)] " + text + " -> " + translation)
       }
 
       return translation
@@ -401,7 +401,7 @@ public final class AITranslate: @unchecked Sendable {
       await reporter.error("Failed to translate \(text) into \(target)")
 
       if verbose {
-        print("[💥]" + error.localizedDescription)
+        await reporter.verboseLog("[💥] " + error.localizedDescription)
       }
 
       return nil

--- a/Sources/AITranslateLib/AITranslate.swift
+++ b/Sources/AITranslateLib/AITranslate.swift
@@ -124,16 +124,33 @@ public final class AITranslate: @unchecked Sendable {
         }
       }
 
-      await reporter.translationStarted(totalEntries: workItems.count, languages: languages)
-
-      // Group by language, then chunk into batches.
       let byLanguage = Dictionary(grouping: workItems, by: \.language)
-      var allBatches: [(language: String, items: [WorkItem])] = []
+      let perLanguageCounts = byLanguage.mapValues { $0.count }
+      let activeLanguages = languages.filter { byLanguage[$0] != nil }
 
-      for (lang, items) in byLanguage {
-        for chunk in items.chunked(into: Self.batchSize) {
-          allBatches.append((lang, chunk))
+      await reporter.translationStarted(
+        totalEntries: workItems.count,
+        languages: activeLanguages,
+        perLanguageCounts: perLanguageCounts
+      )
+
+      // Chunk each language's items into batches, then interleave across languages
+      // so the overall progress bar advances evenly.
+      var perLanguageBatches: [[(language: String, items: [WorkItem])]] = []
+      for lang in activeLanguages {
+        guard let items = byLanguage[lang] else { continue }
+        perLanguageBatches.append(items.chunked(into: Self.batchSize).map { (lang, $0) })
+      }
+
+      var allBatches: [(language: String, items: [WorkItem])] = []
+      var index = 0
+      while allBatches.count < perLanguageBatches.reduce(0, { $0 + $1.count }) {
+        for langBatches in perLanguageBatches {
+          if index < langBatches.count {
+            allBatches.append(langBatches[index])
+          }
         }
+        index += 1
       }
 
       // Process batches concurrently, apply results serially.

--- a/Sources/AITranslateLib/AITranslate.swift
+++ b/Sources/AITranslateLib/AITranslate.swift
@@ -22,6 +22,23 @@ public final class AITranslate: @unchecked Sendable {
     Treat multi-letter abbreviations (such as common technical acronyms like "HTML", "URL", "API", "HTTP", "HTTPS", "JSON", "XML", "CPU", "GPU", "RAM", "ID", "UI", "UX", etc) as case-sensitive and do not translate them.
     """
 
+  static let batchSystemPrompt =
+    """
+    You are a translator tool that translates UI strings for a software application.
+    You will receive a JSON array of entries to translate. Each entry has an "id" (integer),
+    "text" (the string to translate), and optionally "context" (describing how the text is used).
+
+    Rules:
+    - Translate each entry's "text" from the source language to the target language.
+    - Include *only* the translation for each entry — no metadata, tags, periods, quotes, or new lines unless present in the original.
+    - Placeholders (like %@, %d, %1$@, etc) must be preserved exactly as they appear.
+    - Multi-letter abbreviations (HTML, URL, API, HTTP, HTTPS, JSON, XML, CPU, GPU, RAM, ID, UI, UX, etc) are case-sensitive and must not be translated.
+
+    Return a JSON object with a "translations" array containing the translated strings in the same order as the input entries.
+    """
+
+  static let batchSize = 20
+
   let inputFile: URL
   let languages: [String]
   let openAIKey: String
@@ -65,45 +82,94 @@ public final class AITranslate: @unchecked Sendable {
         from: try Data(contentsOf: inputFile)
       )
 
-      // Compute per-entry translation count: for each entry, how many languages need translating.
-      var totalTranslations = 0
-      for entry in catalog.strings {
-        for lang in languages {
-          let unit = entry.value.localizations?[lang]
-          if let unit, unit.hasTranslation, force == false {
-            continue
-          }
-          totalTranslations += 1
-        }
-      }
-
-      await reporter.translationStarted(totalEntries: totalTranslations, languages: languages)
-
       // Force lazy initialization before concurrent access.
       _ = self.api
 
+      // Collect all work items, handling untranslatable entries immediately.
+      var workItems: [WorkItem] = []
+
+      for (key, group) in catalog.strings {
+        let localizationEntries = group.localizations ?? [:]
+
+        for lang in languages {
+          let unit = localizationEntries[lang]
+
+          if let unit, unit.hasTranslation, force == false {
+            continue
+          }
+
+          if let unit, unit.isSupportedFormat == false {
+            await reporter.warning("Unsupported format in entry with key: \(key)")
+            continue
+          }
+
+          let sourceText = localizationEntries[catalog.sourceLanguage]?.stringUnit?.value ?? key
+
+          // Handle text that doesn't need API translation.
+          if isUntranslatable(sourceText) {
+            if group.localizations == nil { group.localizations = [:] }
+            group.localizations?[lang] = LocalizationUnit(
+              stringUnit: StringUnit(state: "translated", value: sourceText)
+            )
+            continue
+          }
+
+          workItems.append(WorkItem(
+            key: key,
+            sourceText: sourceText,
+            context: group.comment,
+            localizationGroup: group,
+            language: lang
+          ))
+        }
+      }
+
+      await reporter.translationStarted(totalEntries: workItems.count, languages: languages)
+
+      // Group by language, then chunk into batches.
+      let byLanguage = Dictionary(grouping: workItems, by: \.language)
+      var allBatches: [(language: String, items: [WorkItem])] = []
+
+      for (lang, items) in byLanguage {
+        for chunk in items.chunked(into: Self.batchSize) {
+          allBatches.append((lang, chunk))
+        }
+      }
+
+      // Process batches concurrently, apply results serially.
       let maxConcurrent = 5
 
-      try await withThrowingTaskGroup(of: Void.self) { group in
+      try await withThrowingTaskGroup(
+        of: [(item: WorkItem, translation: String?)].self
+      ) { group in
         var inFlight = 0
 
-        for entry in catalog.strings {
+        for batch in allBatches {
           if inFlight >= maxConcurrent {
-            try await group.next()
+            if let results = try await group.next() {
+              await applyResults(results)
+            }
             inFlight -= 1
           }
 
+          let items = batch.items
+          let lang = batch.language
           group.addTask {
-            try await self.processEntry(
-              key: entry.key,
-              localizationGroup: entry.value,
-              sourceLanguage: catalog.sourceLanguage
+            let inputs = items.map { (sourceText: $0.sourceText, context: $0.context) }
+            let translations = try await self.performBatchTranslation(
+              entries: inputs,
+              from: catalog.sourceLanguage,
+              to: lang,
+              api: self.api
             )
+            return zip(items, translations).map { (item: $0.0, translation: $0.1) }
           }
           inFlight += 1
         }
 
-        while let _ = try await group.next() {}
+        while let results = try await group.next() {
+          await applyResults(results)
+        }
       }
 
       try save(catalog)
@@ -113,6 +179,115 @@ public final class AITranslate: @unchecked Sendable {
       throw error
     }
   }
+
+  private func applyResults(_ results: [(item: WorkItem, translation: String?)]) async {
+    for (item, translation) in results {
+      if item.localizationGroup.localizations == nil {
+        item.localizationGroup.localizations = [:]
+      }
+      item.localizationGroup.localizations?[item.language] = LocalizationUnit(
+        stringUnit: StringUnit(
+          state: translation != nil ? "translated" : "error",
+          value: translation ?? ""
+        )
+      )
+
+      if verbose, let translation {
+        print("[\(item.language)] " + item.sourceText + " -> " + translation)
+      }
+
+      await reporter.translationCompleted(
+        key: item.key,
+        language: item.language,
+        success: translation != nil
+      )
+    }
+  }
+
+  func isUntranslatable(_ text: String) -> Bool {
+    text.isEmpty ||
+      text.trimmingCharacters(
+        in: .whitespacesAndNewlines
+          .union(.symbols)
+          .union(.controlCharacters)
+      ).isEmpty
+  }
+
+  // MARK: - Batch Translation
+
+  func performBatchTranslation(
+    entries: [(sourceText: String, context: String?)],
+    from source: String,
+    to target: String,
+    api: API
+  ) async throws -> [String?] {
+    let batchEntries = entries.enumerated().map { (i, entry) in
+      TranslationBatchEntry(id: i, text: entry.sourceText, context: entry.context)
+    }
+
+    let entriesJSON = try String(
+      data: JSONEncoder().encode(batchEntries),
+      encoding: .utf8
+    )!
+
+    let userMessage = "<source>\(source)</source><target>\(target)</target><entries>\(entriesJSON)</entries>"
+
+    let query = ChatQuery(
+      messages: [
+        .init(role: .system, content: Self.batchSystemPrompt)!,
+        .init(role: .user, content: userMessage)!
+      ],
+      model: .gpt5_mini,
+      responseFormat: .jsonSchema(
+        .init(
+          name: "batch-translations",
+          schema: .derivedJsonSchema(BatchTranslationResponse.self),
+          strict: true
+        )
+      )
+    )
+
+    do {
+      let result = try await api.chats(query: query)
+      let content = result.choices.first?.message.content ?? ""
+
+      guard let data = content.data(using: .utf8),
+            let response = try? JSONDecoder().decode(BatchTranslationResponse.self, from: data),
+            response.translations.count == entries.count else {
+        // Count mismatch or parse failure: fall back to individual calls.
+        await reporter.warning("Batch response mismatch for \(target), falling back to individual translations")
+        return try await fallbackToIndividual(entries: entries, from: source, to: target, api: api)
+      }
+
+      return response.translations.map { $0 as String? }
+    } catch {
+      // Batch call failed entirely: fall back to individual calls.
+      await reporter.warning("Batch call failed for \(target), falling back to individual translations")
+      return try await fallbackToIndividual(entries: entries, from: source, to: target, api: api)
+    }
+  }
+
+  private func fallbackToIndividual(
+    entries: [(sourceText: String, context: String?)],
+    from source: String,
+    to target: String,
+    api: API
+  ) async throws -> [String?] {
+    var results: [String?] = []
+    for entry in entries {
+      let result = try await performTranslation(
+        entry.sourceText,
+        from: source,
+        to: target,
+        context: entry.context,
+        api: api
+      )
+      results.append(result)
+    }
+    return results
+  }
+
+  // MARK: - Single Translation (used by fallback and tests)
 
   func processEntry(
     key: String,
@@ -193,12 +368,7 @@ public final class AITranslate: @unchecked Sendable {
   ) async throws -> String? {
 
     // Skip text that is generally not translated.
-    if text.isEmpty ||
-        text.trimmingCharacters(
-          in: .whitespacesAndNewlines
-            .union(.symbols)
-            .union(.controlCharacters)
-        ).isEmpty {
+    if isUntranslatable(text) {
       return text
     }
 
@@ -235,6 +405,38 @@ public final class AITranslate: @unchecked Sendable {
       }
 
       return nil
+    }
+  }
+}
+
+// MARK: - Batch Types
+
+struct TranslationBatchEntry: Codable {
+  let id: Int
+  let text: String
+  let context: String?
+}
+
+struct BatchTranslationResponse: JSONSchemaConvertible {
+  let translations: [String]
+
+  static var example: BatchTranslationResponse {
+    BatchTranslationResponse(translations: ["Hallo", "Speichern", "Abbrechen"])
+  }
+}
+
+struct WorkItem {
+  let key: String
+  let sourceText: String
+  let context: String?
+  let localizationGroup: LocalizationGroup
+  let language: String
+}
+
+extension Array {
+  func chunked(into size: Int) -> [[Element]] {
+    stride(from: 0, to: count, by: size).map {
+      Array(self[$0..<Swift.min($0 + size, count)])
     }
   }
 }

--- a/Sources/AITranslateLib/API.swift
+++ b/Sources/AITranslateLib/API.swift
@@ -40,6 +40,8 @@ extension OpenAI: API {}
 
 class MockAPI: API {
   var responseContent = "mock translation"
+  /// Per-entry translations for batch calls. When set, batch queries return these instead of `responseContent`.
+  var batchTranslations: [String]?
   var error: Error?
   private(set) var receivedQueries: [ChatQuery] = []
 
@@ -48,7 +50,18 @@ class MockAPI: API {
   ) async throws -> ChatResult {
     receivedQueries.append(query)
     if let error { throw error }
-    let escaped = responseContent
+
+    let content: String
+
+    // Detect batch queries by checking for responseFormat (JSON schema).
+    if query.responseFormat != nil, let batchTranslations {
+      let response = BatchTranslationResponse(translations: batchTranslations)
+      content = String(data: try JSONEncoder().encode(response), encoding: .utf8)!
+    } else {
+      content = responseContent
+    }
+
+    let escaped = content
       .replacingOccurrences(of: "\\", with: "\\\\")
       .replacingOccurrences(of: "\"", with: "\\\"")
       .replacingOccurrences(of: "\n", with: "\\n")

--- a/Sources/AITranslateLib/ProgressDisplay.swift
+++ b/Sources/AITranslateLib/ProgressDisplay.swift
@@ -227,8 +227,8 @@ public actor RichProgressReporter: ProgressReporter {
         self.verbose = verbose
     }
 
-    public func translationStarted(totalEntries: Int, languages: [String]) async {
-        await progress.configure(totalEntries: totalEntries, languages: languages)
+    public func translationStarted(totalEntries: Int, languages: [String], perLanguageCounts: [String: Int]) async {
+        await progress.configure(totalEntries: totalEntries, languages: languages, perLanguageCounts: perLanguageCounts)
         display.start()
     }
 

--- a/Sources/AITranslateLib/ProgressDisplay.swift
+++ b/Sources/AITranslateLib/ProgressDisplay.swift
@@ -236,6 +236,10 @@ public actor RichProgressReporter: ProgressReporter {
         await progress.recordCompletion(key: key, language: language, success: success)
     }
 
+    public func verboseLog(_ message: String) {
+        verboseMessages.append(message)
+    }
+
     public func warning(_ message: String) {
         if verbose {
             verboseMessages.append("[⚠️] \(message)")

--- a/Sources/AITranslateLib/ProgressDisplay.swift
+++ b/Sources/AITranslateLib/ProgressDisplay.swift
@@ -131,13 +131,35 @@ public final class ProgressDisplay: Sendable {
                 statusIcon = "+"
                 statusLabel = "done   "
             }
-            let langPct = lang.total > 0 ? Int(Double(lang.completed) / Double(lang.total) * 100) : 0
+            let langPct = lang.total > 0 ? min(100, Int(Double(lang.completed) / Double(lang.total) * 100)) : 0
             let langBarWidth = max(5, width - 36)
             let langFilled = Int(Double(langPct) / 100.0 * Double(langBarWidth))
             let langBar = String(repeating: "█", count: langFilled) + String(repeating: "░", count: langBarWidth - langFilled)
             let failStr = lang.failed > 0 ? " (\(lang.failed) failed)" : ""
             let row = "  \(langLabel) \(statusIcon) \(statusLabel) \(langBar) \(String(format: "%3d%%", langPct))\(failStr)"
             lines.append(padLine(row, width: width))
+        }
+
+        // Verbose log section — fill remaining terminal height with recent log lines.
+        if !snapshot.recentLogLines.isEmpty {
+            let height = terminalHeight()
+            // 1 line for bottom border, leave at least 1 blank line of margin
+            let headerLines = lines.count
+            let availableLogRows = max(0, height - headerLines - 2)
+
+            if availableLogRows > 0 {
+                lines.append(padLine("", width: width))
+                let logDivider = "  " + String(repeating: "─", count: width - 4)
+                lines.append(padLine(logDivider, width: width))
+
+                let visibleRows = availableLogRows - 2  // divider + blank we just added
+                let logLines = snapshot.recentLogLines
+                let start = max(0, logLines.count - visibleRows)
+                for i in start..<logLines.count {
+                    let truncated = truncateToWidth(logLines[i], maxWidth: width - 4)
+                    lines.append(padLine("  \(truncated)", width: width))
+                }
+            }
         }
 
         // Bottom border
@@ -147,6 +169,12 @@ public final class ProgressDisplay: Sendable {
         var buf = "\u{1B}[H"
         for line in lines {
             buf += line + "\u{1B}[K\n"  // clear rest of line in case terminal is wider now
+        }
+        // Clear any leftover lines below the panel from a previous frame
+        let height = terminalHeight()
+        let remaining = height - lines.count
+        for _ in 0..<remaining {
+            buf += "\u{1B}[K\n"
         }
 
         writeStderr(buf)
@@ -170,6 +198,19 @@ public final class ProgressDisplay: Sendable {
         let w = displayWidth(str)
         if w >= length { return str }
         return str + String(repeating: " ", count: length - w)
+    }
+
+    private func truncateToWidth(_ string: String, maxWidth: Int) -> String {
+        var width = 0
+        var end = string.startIndex
+        for scalar in string.unicodeScalars {
+            let w = wcwidth(wchar_t(scalar.value))
+            let charWidth = w > 0 ? Int(w) : (w == 0 ? 0 : 1)
+            if width + charWidth > maxWidth { break }
+            width += charWidth
+            end = string.unicodeScalars.index(after: end)
+        }
+        return String(string[string.startIndex..<end])
     }
 
     private func displayWidth(_ string: String) -> Int {
@@ -217,7 +258,6 @@ private func writeStderr(_ string: String) {
 public actor RichProgressReporter: ProgressReporter {
     private let progress: TranslationProgress
     private let display: ProgressDisplay
-    private var verboseMessages: [String] = []
     private let verbose: Bool
 
     public init(verbose: Bool = false) {
@@ -237,19 +277,19 @@ public actor RichProgressReporter: ProgressReporter {
     }
 
     public func verboseLog(_ message: String) {
-        verboseMessages.append(message)
+        Task { await progress.appendLog(message) }
     }
 
     public func warning(_ message: String) {
         if verbose {
-            verboseMessages.append("[⚠️] \(message)")
+            Task { await progress.appendLog("[warn] \(message)") }
         }
         Task { await progress.recordWarning() }
     }
 
     public func error(_ message: String) {
         if verbose {
-            verboseMessages.append("[❌] \(message)")
+            Task { await progress.appendLog("[err] \(message)") }
         }
         Task { await progress.recordError() }
     }
@@ -261,11 +301,6 @@ public actor RichProgressReporter: ProgressReporter {
         // Print summary to main screen after alternate buffer exits
         let elapsed = formatElapsed(snap.elapsedSeconds)
         print("[✅] Translation complete (\(elapsed) elapsed, \(snap.warningCount) warnings, \(snap.errorCount) errors)")
-
-        // Print buffered verbose messages after panel teardown
-        for msg in verboseMessages {
-            print(msg)
-        }
     }
 
     private func formatElapsed(_ seconds: TimeInterval) -> String {

--- a/Sources/AITranslateLib/ProgressDisplay.swift
+++ b/Sources/AITranslateLib/ProgressDisplay.swift
@@ -1,0 +1,277 @@
+//
+//  ProgressDisplay.swift
+//
+//
+//  Created by AI on 3/25/26.
+//
+
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// Renders a live-updating bordered panel to stderr using the alternate screen buffer.
+/// Uses the same mechanism as vim/htop/less — no cursor-up needed.
+public final class ProgressDisplay: Sendable {
+    private let progress: TranslationProgress
+    private let renderTask: SendableBox<Task<Void, Never>?>
+    private let minWidth = 42
+
+    public init(progress: TranslationProgress) {
+        self.progress = progress
+        self.renderTask = SendableBox(nil)
+    }
+
+    public func start() {
+        // Switch to alternate screen buffer + hide cursor
+        writeStderr("\u{1B}[?1049h\u{1B}[?25l")
+
+        // Install SIGINT handler to restore terminal state before exit
+        signal(SIGINT) { _ in
+            var buf = Array("\u{1B}[?25h\u{1B}[?1049l\n".utf8)
+            write(STDERR_FILENO, &buf, buf.count)
+            _Exit(130)
+        }
+
+        let task = Task { [self] in
+            while !Task.isCancelled {
+                let snap = await self.progress.snapshot()
+                self.render(snap)
+                if snap.isFinished { break }
+                try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
+            }
+        }
+        renderTask.value = task
+    }
+
+    public func stop() async -> ProgressSnapshot {
+        renderTask.value?.cancel()
+        await renderTask.value?.value
+        renderTask.value = nil
+
+        // Final render
+        let snap = await progress.snapshot()
+        render(snap)
+
+        // Brief pause so the user can see the completed state
+        try? await Task.sleep(nanoseconds: 500_000_000) // 500ms
+
+        // Show cursor + switch back to main screen buffer
+        writeStderr("\u{1B}[?25h\u{1B}[?1049l")
+        signal(SIGINT, SIG_DFL)
+
+        return snap
+    }
+
+    private func terminalWidth() -> Int {
+        var ws = winsize()
+        if ioctl(STDERR_FILENO, UInt(TIOCGWINSZ), &ws) == 0, ws.ws_col > 0 {
+            return max(Int(ws.ws_col), minWidth)
+        }
+        return 80
+    }
+
+    private func terminalHeight() -> Int {
+        var ws = winsize()
+        if ioctl(STDERR_FILENO, UInt(TIOCGWINSZ), &ws) == 0, ws.ws_row > 0 {
+            return Int(ws.ws_row)
+        }
+        return 24
+    }
+
+    func render(_ snapshot: ProgressSnapshot) {
+        let width = terminalWidth()
+        var lines: [String] = []
+
+        let title = " AITranslate Progress "
+        let topBorder = buildTopBorder(width: width, title: title)
+        lines.append(topBorder)
+
+        // Progress bar line
+        let pct = snapshot.percentage
+        let barWidth = max(10, width - 10)
+        let filled = Int(Double(pct) / 100.0 * Double(barWidth))
+        let bar = String(repeating: "█", count: filled) + String(repeating: "░", count: barWidth - filled)
+        let pctStr = String(format: "%3d%%", pct)
+        lines.append(padLine("  \(bar) \(pctStr)", width: width))
+
+        // Blank separator
+        lines.append(padLine("", width: width))
+
+        // Stats line
+        let elapsed = formatElapsed(snapshot.elapsedSeconds)
+        let statsLeft = "  Elapsed: \(elapsed)"
+        let statsRight = "warn: \(snapshot.warningCount)  err: \(snapshot.errorCount)  "
+        let statsGap = max(1, width - 2 - displayWidth(statsLeft) - displayWidth(statsRight))
+        lines.append("│" + statsLeft + String(repeating: " ", count: statsGap) + statsRight + "│")
+
+        // Blank separator
+        lines.append(padLine("", width: width))
+
+        // Per-language header
+        lines.append(padLine("  Language   Status       Progress", width: width))
+        let divider = "  " + String(repeating: "─", count: width - 4)
+        lines.append(padLine(divider, width: width))
+
+        // Per-language rows
+        for lang in snapshot.languages {
+            let langLabel = padRight(lang.language, to: 9)
+            let statusIcon: String
+            let statusLabel: String
+            switch lang.status {
+            case .pending:
+                statusIcon = "-"
+                statusLabel = "pending"
+            case .active:
+                statusIcon = "*"
+                statusLabel = "active "
+            case .done:
+                statusIcon = "+"
+                statusLabel = "done   "
+            }
+            let langPct = lang.total > 0 ? Int(Double(lang.completed) / Double(lang.total) * 100) : 0
+            let langBarWidth = max(5, width - 36)
+            let langFilled = Int(Double(langPct) / 100.0 * Double(langBarWidth))
+            let langBar = String(repeating: "█", count: langFilled) + String(repeating: "░", count: langBarWidth - langFilled)
+            let failStr = lang.failed > 0 ? " (\(lang.failed) failed)" : ""
+            let row = "  \(langLabel) \(statusIcon) \(statusLabel) \(langBar) \(String(format: "%3d%%", langPct))\(failStr)"
+            lines.append(padLine(row, width: width))
+        }
+
+        // Bottom border
+        lines.append("└" + String(repeating: "─", count: width - 2) + "┘")
+
+        // Cursor home (1,1) then write the entire panel
+        var buf = "\u{1B}[H"
+        for line in lines {
+            buf += line + "\u{1B}[K\n"  // clear rest of line in case terminal is wider now
+        }
+
+        writeStderr(buf)
+    }
+
+    private func buildTopBorder(width: Int, title: String) -> String {
+        let titleLen = displayWidth(title)
+        let remaining = width - 2 - titleLen
+        let leftDash = max(1, remaining / 2)
+        let rightDash = max(1, remaining - leftDash)
+        return "┌" + String(repeating: "─", count: leftDash) + title + String(repeating: "─", count: rightDash) + "┐"
+    }
+
+    private func padLine(_ content: String, width: Int) -> String {
+        let visibleLen = displayWidth(content)
+        let padding = max(0, width - 2 - visibleLen)
+        return "│" + content + String(repeating: " ", count: padding) + "│"
+    }
+
+    private func padRight(_ str: String, to length: Int) -> String {
+        let w = displayWidth(str)
+        if w >= length { return str }
+        return str + String(repeating: " ", count: length - w)
+    }
+
+    private func displayWidth(_ string: String) -> Int {
+        var width = 0
+        for scalar in string.unicodeScalars {
+            let w = wcwidth(wchar_t(scalar.value))
+            width += w > 0 ? Int(w) : (w == 0 ? 0 : 1)
+        }
+        return width
+    }
+
+    private func formatElapsed(_ seconds: TimeInterval) -> String {
+        let total = Int(seconds)
+        let h = total / 3600
+        let m = (total % 3600) / 60
+        let s = total % 60
+        if h > 0 {
+            return String(format: "%d:%02d:%02d", h, m, s)
+        }
+        return String(format: "%d:%02d", m, s)
+    }
+}
+
+/// Thread-safe mutable box for use inside Sendable types.
+final class SendableBox<T>: @unchecked Sendable {
+    var value: T
+    init(_ value: T) { self.value = value }
+}
+
+private func writeStderr(_ string: String) {
+    let data = Array(string.utf8)
+    var offset = 0
+    while offset < data.count {
+        let result = data[offset...].withUnsafeBufferPointer { ptr in
+            write(STDERR_FILENO, ptr.baseAddress!, ptr.count)
+        }
+        if result <= 0 { break }
+        offset += result
+    }
+}
+
+// MARK: - RichProgressReporter
+
+/// Full TUI progress reporter combining TranslationProgress actor + ProgressDisplay renderer.
+public actor RichProgressReporter: ProgressReporter {
+    private let progress: TranslationProgress
+    private let display: ProgressDisplay
+    private var verboseMessages: [String] = []
+    private let verbose: Bool
+
+    public init(verbose: Bool = false) {
+        let progress = TranslationProgress()
+        self.progress = progress
+        self.display = ProgressDisplay(progress: progress)
+        self.verbose = verbose
+    }
+
+    public func translationStarted(totalEntries: Int, languages: [String]) async {
+        await progress.configure(totalEntries: totalEntries, languages: languages)
+        display.start()
+    }
+
+    public func translationCompleted(key: String, language: String, success: Bool) async {
+        await progress.recordCompletion(key: key, language: language, success: success)
+    }
+
+    public func warning(_ message: String) {
+        if verbose {
+            verboseMessages.append("[⚠️] \(message)")
+        }
+        Task { await progress.recordWarning() }
+    }
+
+    public func error(_ message: String) {
+        if verbose {
+            verboseMessages.append("[❌] \(message)")
+        }
+        Task { await progress.recordError() }
+    }
+
+    public func finished() async {
+        await progress.markFinished()
+        let snap = await display.stop()
+
+        // Print summary to main screen after alternate buffer exits
+        let elapsed = formatElapsed(snap.elapsedSeconds)
+        print("[✅] Translation complete (\(elapsed) elapsed, \(snap.warningCount) warnings, \(snap.errorCount) errors)")
+
+        // Print buffered verbose messages after panel teardown
+        for msg in verboseMessages {
+            print(msg)
+        }
+    }
+
+    private func formatElapsed(_ seconds: TimeInterval) -> String {
+        let total = Int(seconds)
+        let h = total / 3600
+        let m = (total % 3600) / 60
+        let s = total % 60
+        if h > 0 {
+            return String(format: "%d:%02d:%02d", h, m, s)
+        }
+        return String(format: "%d:%02d", m, s)
+    }
+}

--- a/Sources/AITranslateLib/ProgressReporter.swift
+++ b/Sources/AITranslateLib/ProgressReporter.swift
@@ -1,0 +1,60 @@
+//
+//  ProgressReporter.swift
+//
+//
+//  Created by AI on 3/25/26.
+//
+
+import Foundation
+
+public protocol ProgressReporter: Sendable {
+    func translationStarted(totalEntries: Int, languages: [String]) async
+    func translationCompleted(key: String, language: String, success: Bool) async
+    func warning(_ message: String) async
+    func error(_ message: String) async
+    func finished() async
+}
+
+/// Simple text-based reporter for non-TTY environments (pipes, CI, --no-tui).
+/// Replicates the original print-based output.
+public actor SimpleProgressReporter: ProgressReporter {
+    private var totalEntries = 0
+    private var entriesCompleted = 0
+    private var previousPercentage: Int = -1
+    private var startTime = Date()
+
+    public init() {}
+
+    public func translationStarted(totalEntries: Int, languages: [String]) {
+        self.totalEntries = totalEntries
+        self.startTime = Date()
+        self.entriesCompleted = 0
+        self.previousPercentage = -1
+    }
+
+    public func translationCompleted(key: String, language: String, success: Bool) {
+        entriesCompleted += 1
+        guard totalEntries > 0 else { return }
+        let pct = Int(Double(entriesCompleted) / Double(totalEntries) * 100)
+        if pct != previousPercentage, pct % 10 == 0 {
+            print("[⏳] \(pct)%")
+            previousPercentage = pct
+        }
+    }
+
+    public func warning(_ message: String) {
+        print("[⚠️] \(message)")
+    }
+
+    public func error(_ message: String) {
+        print("[❌] \(message)")
+    }
+
+    public func finished() {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.hour, .minute, .second]
+        formatter.unitsStyle = .full
+        let elapsed = formatter.string(from: Date().timeIntervalSince(startTime)) ?? "unknown"
+        print("[✅] 100% \n[⏰] Translations time: \(elapsed)")
+    }
+}

--- a/Sources/AITranslateLib/ProgressReporter.swift
+++ b/Sources/AITranslateLib/ProgressReporter.swift
@@ -10,6 +10,7 @@ import Foundation
 public protocol ProgressReporter: Sendable {
     func translationStarted(totalEntries: Int, languages: [String]) async
     func translationCompleted(key: String, language: String, success: Bool) async
+    func verboseLog(_ message: String) async
     func warning(_ message: String) async
     func error(_ message: String) async
     func finished() async
@@ -40,6 +41,10 @@ public actor SimpleProgressReporter: ProgressReporter {
             print("[⏳] \(pct)%")
             previousPercentage = pct
         }
+    }
+
+    public func verboseLog(_ message: String) {
+        print(message)
     }
 
     public func warning(_ message: String) {

--- a/Sources/AITranslateLib/ProgressReporter.swift
+++ b/Sources/AITranslateLib/ProgressReporter.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public protocol ProgressReporter: Sendable {
-    func translationStarted(totalEntries: Int, languages: [String]) async
+    func translationStarted(totalEntries: Int, languages: [String], perLanguageCounts: [String: Int]) async
     func translationCompleted(key: String, language: String, success: Bool) async
     func verboseLog(_ message: String) async
     func warning(_ message: String) async
@@ -26,7 +26,7 @@ public actor SimpleProgressReporter: ProgressReporter {
 
     public init() {}
 
-    public func translationStarted(totalEntries: Int, languages: [String]) {
+    public func translationStarted(totalEntries: Int, languages: [String], perLanguageCounts: [String: Int]) {
         self.totalEntries = totalEntries
         self.startTime = Date()
         self.entriesCompleted = 0

--- a/Sources/AITranslateLib/TranslationProgress.swift
+++ b/Sources/AITranslateLib/TranslationProgress.swift
@@ -1,0 +1,117 @@
+//
+//  TranslationProgress.swift
+//
+//
+//  Created by AI on 3/25/26.
+//
+
+import Foundation
+
+public enum LanguageStatus: Sendable {
+    case pending
+    case active
+    case done
+}
+
+public struct LanguageState: Sendable {
+    public let language: String
+    public var completed: Int = 0
+    public var failed: Int = 0
+    public var total: Int = 0
+    public var status: LanguageStatus = .pending
+}
+
+public struct ProgressSnapshot: Sendable {
+    public let languages: [LanguageState]
+    public let totalEntries: Int
+    public let totalCompleted: Int
+    public let totalFailed: Int
+    public let warningCount: Int
+    public let errorCount: Int
+    public let elapsedSeconds: TimeInterval
+    public let isFinished: Bool
+
+    public var percentage: Int {
+        guard totalEntries > 0 else { return 0 }
+        return min(100, Int(Double(totalCompleted) / Double(totalEntries) * 100))
+    }
+}
+
+public actor TranslationProgress {
+    private var languageStates: [String: LanguageState] = [:]
+    private var languageOrder: [String] = []
+    private var totalEntries: Int = 0
+    private var totalCompleted: Int = 0
+    private var totalFailed: Int = 0
+    private var warningCount: Int = 0
+    private var errorCount: Int = 0
+    private var startTime: Date = Date()
+    private var finished: Bool = false
+
+    public init() {}
+
+    public func configure(totalEntries: Int, languages: [String]) {
+        self.totalEntries = totalEntries
+        self.languageOrder = languages
+        self.startTime = Date()
+        self.finished = false
+        self.totalCompleted = 0
+        self.totalFailed = 0
+        self.warningCount = 0
+        self.errorCount = 0
+
+        for lang in languages {
+            languageStates[lang] = LanguageState(
+                language: lang,
+                total: totalEntries,
+                status: .pending
+            )
+        }
+    }
+
+    public func recordCompletion(key: String, language: String, success: Bool) {
+        guard var state = languageStates[language] else { return }
+        if state.status == .pending {
+            state.status = .active
+        }
+        state.completed += 1
+        if !success {
+            state.failed += 1
+            totalFailed += 1
+        }
+        if state.completed >= state.total {
+            state.status = .done
+        }
+        languageStates[language] = state
+        totalCompleted += 1
+    }
+
+    public func recordWarning() {
+        warningCount += 1
+    }
+
+    public func recordError() {
+        errorCount += 1
+    }
+
+    public func markFinished() {
+        finished = true
+        for lang in languageOrder {
+            languageStates[lang]?.status = .done
+        }
+    }
+
+    public func snapshot() -> ProgressSnapshot {
+        let states = languageOrder.compactMap { languageStates[$0] }
+        return ProgressSnapshot(
+            languages: states,
+            totalEntries: totalEntries,
+            totalCompleted: totalCompleted,
+            totalFailed: totalFailed,
+            warningCount: warningCount,
+            errorCount: errorCount,
+            elapsedSeconds: Date().timeIntervalSince(startTime),
+            isFinished: finished
+        )
+    }
+}

--- a/Sources/AITranslateLib/TranslationProgress.swift
+++ b/Sources/AITranslateLib/TranslationProgress.swift
@@ -50,7 +50,7 @@ public actor TranslationProgress {
 
     public init() {}
 
-    public func configure(totalEntries: Int, languages: [String]) {
+    public func configure(totalEntries: Int, languages: [String], perLanguageCounts: [String: Int] = [:]) {
         self.totalEntries = totalEntries
         self.languageOrder = languages
         self.startTime = Date()
@@ -60,10 +60,11 @@ public actor TranslationProgress {
         self.warningCount = 0
         self.errorCount = 0
 
+        let defaultPerLang = languages.isEmpty ? 0 : totalEntries / languages.count
         for lang in languages {
             languageStates[lang] = LanguageState(
                 language: lang,
-                total: totalEntries,
+                total: perLanguageCounts[lang] ?? defaultPerLang,
                 status: .pending
             )
         }

--- a/Sources/AITranslateLib/TranslationProgress.swift
+++ b/Sources/AITranslateLib/TranslationProgress.swift
@@ -30,6 +30,7 @@ public struct ProgressSnapshot: Sendable {
     public let errorCount: Int
     public let elapsedSeconds: TimeInterval
     public let isFinished: Bool
+    public let recentLogLines: [String]
 
     public var percentage: Int {
         guard totalEntries > 0 else { return 0 }
@@ -47,8 +48,17 @@ public actor TranslationProgress {
     private var errorCount: Int = 0
     private var startTime: Date = Date()
     private var finished: Bool = false
+    private var logLines: [String] = []
+    private let maxLogLines = 200
 
     public init() {}
+
+    public func appendLog(_ message: String) {
+        logLines.append(message)
+        if logLines.count > maxLogLines {
+            logLines.removeFirst(logLines.count - maxLogLines)
+        }
+    }
 
     public func configure(totalEntries: Int, languages: [String], perLanguageCounts: [String: Int] = [:]) {
         self.totalEntries = totalEntries
@@ -112,7 +122,8 @@ public actor TranslationProgress {
             warningCount: warningCount,
             errorCount: errorCount,
             elapsedSeconds: Date().timeIntervalSince(startTime),
-            isFinished: finished
+            isFinished: finished,
+            recentLogLines: logLines
         )
     }
 }

--- a/Tests/AITranslateTests/AITranslateTests.swift
+++ b/Tests/AITranslateTests/AITranslateTests.swift
@@ -20,6 +20,18 @@ struct AITranslateCommandTests {
     #expect(parsed.openAIKey == "test-api-key")
   }
 
+  @Test func parsesNoTuiFlag() throws {
+    let command = try AITranslateCommand.parseAsRoot([
+      "/path/to/Localizable.xcstrings",
+      "-o", "test-api-key",
+      "-l", "de",
+      "--no-tui"
+    ])
+
+    let parsed = try #require(command as? AITranslateCommand)
+    #expect(parsed.noTui == true)
+  }
+
   @Test func mockAPIUsedInTestEnvironment() {
     let translate = AITranslateLib.AITranslate(
       inputFile: URL(fileURLWithPath: "/tmp/test.xcstrings"),

--- a/Tests/AITranslateTests/ProgressDisplayTests.swift
+++ b/Tests/AITranslateTests/ProgressDisplayTests.swift
@@ -1,0 +1,51 @@
+import Testing
+import Foundation
+@testable import AITranslateLib
+
+struct ProgressDisplayTests {
+  @Test func renderProducesOutput() async {
+    let progress = TranslationProgress()
+    await progress.configure(totalEntries: 10, languages: ["de", "fr"])
+    let display = ProgressDisplay(progress: progress)
+
+    // Just verify render doesn't crash with a fresh snapshot
+    let snap = await progress.snapshot()
+    display.render(snap)
+  }
+
+  @Test func renderAfterCompletions() async {
+    let progress = TranslationProgress()
+    await progress.configure(totalEntries: 4, languages: ["de", "fr"])
+
+    await progress.recordCompletion(key: "a", language: "de", success: true)
+    await progress.recordCompletion(key: "a", language: "fr", success: true)
+    await progress.recordCompletion(key: "b", language: "de", success: false)
+
+    let display = ProgressDisplay(progress: progress)
+    let snap = await progress.snapshot()
+    display.render(snap)
+  }
+
+  @Test func renderFinishedState() async {
+    let progress = TranslationProgress()
+    await progress.configure(totalEntries: 2, languages: ["de"])
+
+    await progress.recordCompletion(key: "a", language: "de", success: true)
+    await progress.recordCompletion(key: "b", language: "de", success: true)
+    await progress.markFinished()
+
+    let display = ProgressDisplay(progress: progress)
+    let snap = await progress.snapshot()
+    display.render(snap)
+    // If we reach here without crash, the render works for the finished state
+  }
+
+  @Test func snapshotPercentageIsCorrect() async {
+    let progress = TranslationProgress()
+    await progress.configure(totalEntries: 4, languages: ["de"])
+
+    await progress.recordCompletion(key: "a", language: "de", success: true)
+    let snap = await progress.snapshot()
+    #expect(snap.percentage == 25)
+  }
+}

--- a/Tests/AITranslateTests/TranslationProgressTests.swift
+++ b/Tests/AITranslateTests/TranslationProgressTests.swift
@@ -1,0 +1,112 @@
+import Testing
+import Foundation
+@testable import AITranslateLib
+
+struct TranslationProgressTests {
+  @Test func initialSnapshotIsZero() async {
+    let progress = TranslationProgress()
+    await progress.configure(totalEntries: 10, languages: ["de", "fr"])
+    let snap = await progress.snapshot()
+
+    #expect(snap.totalEntries == 10)
+    #expect(snap.totalCompleted == 0)
+    #expect(snap.totalFailed == 0)
+    #expect(snap.percentage == 0)
+    #expect(snap.isFinished == false)
+    #expect(snap.languages.count == 2)
+    #expect(snap.languages[0].language == "de")
+    #expect(snap.languages[1].language == "fr")
+  }
+
+  @Test func recordCompletionUpdatesState() async {
+    let progress = TranslationProgress()
+    await progress.configure(totalEntries: 2, languages: ["de"])
+
+    await progress.recordCompletion(key: "hello", language: "de", success: true)
+    let snap = await progress.snapshot()
+
+    #expect(snap.totalCompleted == 1)
+    #expect(snap.totalFailed == 0)
+    #expect(snap.languages[0].completed == 1)
+    #expect(snap.languages[0].status == .active)
+  }
+
+  @Test func recordFailureUpdatesState() async {
+    let progress = TranslationProgress()
+    await progress.configure(totalEntries: 2, languages: ["de"])
+
+    await progress.recordCompletion(key: "hello", language: "de", success: false)
+    let snap = await progress.snapshot()
+
+    #expect(snap.totalCompleted == 1)
+    #expect(snap.totalFailed == 1)
+    #expect(snap.languages[0].failed == 1)
+  }
+
+  @Test func languageBecomeDoneWhenAllCompleted() async {
+    let progress = TranslationProgress()
+    await progress.configure(totalEntries: 2, languages: ["de"])
+
+    await progress.recordCompletion(key: "a", language: "de", success: true)
+    await progress.recordCompletion(key: "b", language: "de", success: true)
+    let snap = await progress.snapshot()
+
+    #expect(snap.languages[0].status == .done)
+    #expect(snap.percentage == 100)
+  }
+
+  @Test func markFinishedSetsAllDone() async {
+    let progress = TranslationProgress()
+    await progress.configure(totalEntries: 5, languages: ["de", "fr"])
+
+    await progress.markFinished()
+    let snap = await progress.snapshot()
+
+    #expect(snap.isFinished == true)
+    for lang in snap.languages {
+      #expect(lang.status == .done)
+    }
+  }
+
+  @Test func warningAndErrorCounts() async {
+    let progress = TranslationProgress()
+    await progress.configure(totalEntries: 5, languages: ["de"])
+
+    await progress.recordWarning()
+    await progress.recordWarning()
+    await progress.recordError()
+    let snap = await progress.snapshot()
+
+    #expect(snap.warningCount == 2)
+    #expect(snap.errorCount == 1)
+  }
+
+  @Test func percentageClampedTo100() async {
+    let progress = TranslationProgress()
+    await progress.configure(totalEntries: 1, languages: ["de"])
+
+    // Complete more than total (edge case)
+    await progress.recordCompletion(key: "a", language: "de", success: true)
+    await progress.recordCompletion(key: "b", language: "de", success: true)
+    let snap = await progress.snapshot()
+
+    #expect(snap.percentage <= 100)
+  }
+
+  @Test func multipleLanguagesTrackedIndependently() async {
+    let progress = TranslationProgress()
+    await progress.configure(totalEntries: 3, languages: ["de", "fr", "es"])
+
+    await progress.recordCompletion(key: "a", language: "de", success: true)
+    await progress.recordCompletion(key: "a", language: "fr", success: false)
+    let snap = await progress.snapshot()
+
+    #expect(snap.languages[0].completed == 1) // de
+    #expect(snap.languages[0].failed == 0)
+    #expect(snap.languages[1].completed == 1) // fr
+    #expect(snap.languages[1].failed == 1)
+    #expect(snap.languages[2].completed == 0) // es
+    #expect(snap.totalCompleted == 2)
+    #expect(snap.totalFailed == 1)
+  }
+}

--- a/Tests/AITranslateTests/TranslationTests.swift
+++ b/Tests/AITranslateTests/TranslationTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import OpenAI
 @testable import AITranslateLib
 
 struct TranslationTests {
@@ -178,4 +179,106 @@ struct TranslationTests {
     #expect(group.localizations?["fr"]?.stringUnit?.value == "translated")
     #expect(group.localizations?["es"]?.stringUnit?.value == "translated")
   }
+
+  // MARK: - performBatchTranslation
+
+  @Test func batchTranslationReturnsAllTranslations() async throws {
+    let translate = makeTranslate()
+    let mock = makeMockAPI()
+    mock.batchTranslations = ["Hallo", "Speichern", "Abbrechen"]
+
+    let entries: [(sourceText: String, context: String?)] = [
+      ("Hello", nil),
+      ("Save", "button label"),
+      ("Cancel", nil)
+    ]
+
+    let results = try await translate.performBatchTranslation(
+      entries: entries, from: "en", to: "de", api: mock
+    )
+
+    #expect(results.count == 3)
+    #expect(results[0] == "Hallo")
+    #expect(results[1] == "Speichern")
+    #expect(results[2] == "Abbrechen")
+    #expect(mock.receivedQueries.count == 1)
+  }
+
+  @Test func batchTranslationPassesContext() async throws {
+    let translate = makeTranslate()
+    let mock = makeMockAPI()
+    mock.batchTranslations = ["Datei"]
+
+    let entries: [(sourceText: String, context: String?)] = [
+      ("File", "menu item for file operations")
+    ]
+
+    let results = try await translate.performBatchTranslation(
+      entries: entries, from: "en", to: "de", api: mock
+    )
+
+    #expect(results.count == 1)
+    #expect(results[0] == "Datei")
+
+    // Verify the user message contains the context
+    let query = try #require(mock.receivedQueries.first)
+    // The batch query encodes entries as JSON with context field
+    #expect(mock.receivedQueries.count == 1)
+
+    // Verify query uses responseFormat (batch mode)
+    #expect(query.responseFormat != nil)
+  }
+
+  @Test func batchFallsBackOnCountMismatch() async throws {
+    let translate = makeTranslate()
+    let mock = makeMockAPI()
+    // Return wrong number of translations to trigger fallback
+    mock.batchTranslations = ["Hallo"]
+    mock.responseContent = "fallback"
+
+    let entries: [(sourceText: String, context: String?)] = [
+      ("Hello", nil),
+      ("World", nil),
+      ("Test", nil)
+    ]
+
+    let results = try await translate.performBatchTranslation(
+      entries: entries, from: "en", to: "de", api: mock
+    )
+
+    // Should fall back to individual calls (1 batch + 3 individual = 4 total)
+    #expect(results.count == 3)
+    #expect(mock.receivedQueries.count == 4)
+  }
+
+  @Test func batchFallsBackOnAPIError() async throws {
+    let translate = makeTranslate()
+    let mock = makeMockAPI()
+    mock.error = NSError(domain: "test", code: 500)
+
+    let entries: [(sourceText: String, context: String?)] = [
+      ("Hello", nil)
+    ]
+
+    // When batch fails, it falls back to individual calls which also fail,
+    // returning nil for each entry (performTranslation catches errors).
+    let results = try await translate.performBatchTranslation(
+      entries: entries, from: "en", to: "de", api: mock
+    )
+
+    #expect(results.count == 1)
+    #expect(results[0] == nil)
+    // 1 batch call + 1 individual fallback call = 2 total
+    #expect(mock.receivedQueries.count == 2)
+  }
+
+  @Test func isUntranslatableDetectsEmptyAndSymbols() {
+    let translate = makeTranslate()
+    #expect(translate.isUntranslatable("") == true)
+    #expect(translate.isUntranslatable("   ") == true)
+    #expect(translate.isUntranslatable("$$$") == true)
+    #expect(translate.isUntranslatable("Hello") == false)
+    #expect(translate.isUntranslatable("Hello World") == false)
+  }
 }
+


### PR DESCRIPTION
## Summary
- Groups translation entries by language and chunks them into batches of 20
- Sends each batch as a single API call using OpenAI's JSON structured output (`responseFormat: .jsonSchema`)
- Falls back to individual per-string calls on batch failure or response count mismatch
- Context is still passed through for each entry in the batch
- Includes untranslatable text handling (symbols, whitespace) without API calls
- Results applied serially to avoid race conditions on shared catalog state

## Test plan
- [x] All 43 existing + new tests pass (`swift test`)
- [x] New tests: batch returns all translations, context passthrough, count mismatch fallback, API error fallback, `isUntranslatable` helper
- [ ] Manual test with real API key to verify batch responses parse correctly