### PR TITLE
Add batch translations, rich TUI, and Xcode ordering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a small, simple, utility that parses an Xcode `.xcstrings` file, asks ChatGPT to translate each entry, and then saves the results back in the `xcstrings` JSON format.
 
-This tool is hardcoded to use ChatGPT-4. While ChatGPT3.5 is significantly less expensive, it does not provide satisfactory results. Selecting a model via a command-line flag has been deliberately omitted for this reason, thus ensuring this tool does not contribute to a proliferation of poor translations in apps on Apple platforms.  
+This tool is hardcoded to use GPT-5 mini. Selecting a model via a command-line flag has been deliberately omitted to ensure this tool does not contribute to a proliferation of poor translations in apps on Apple platforms.
 
 Please note that is **very strongly** recommend to have translations tested by a qualified human as even ChatGPT-4 will almost certainly not produce perfect results.
 
@@ -21,17 +21,19 @@ swift run ai-translate /path/to/your/Localizable.xcstrings -o <your-openai-API-k
 Help output:
 
 ```
-  USAGE: ai-translate <input-file> --languages <languages> --open-ai-key <open-ai-key> [--verbose] [--skip-backup] [--force]
+  USAGE: ai-translate <input-file> --languages <languages> --open-ai-key <open-ai-key> [--verbose] [--skip-backup] [--force] [--match-xcode-ordering] [--no-tui]
 
   ARGUMENTS:
     <input-file>
 
   OPTIONS:
-    -l, --languages <languages> a comma separated list of language codes (must match the language codes used by xcstrings)
+    -l, --languages <languages> A comma separated list of language codes (must match the language codes used by xcstrings)
     -o, --open-ai-key <open-ai-key>
                             Your OpenAI API key, see: https://platform.openai.com/api-keys
     -v, --verbose
     -s, --skip-backup       By default a backup of the input will be created. When this flag is provided, the backup is skipped.
     -f, --force             Forces all strings to be translated, even if an existing translation is present.
+    --match-xcode-ordering  Sort JSON keys to match Xcode's xcstrings ordering.
+    --no-tui                Disable the rich terminal UI and use simple text output instead.
     -h, --help              Show help information.
 ```

--- a/Sources/AITranslate/AITranslateCommand.swift
+++ b/Sources/AITranslate/AITranslateCommand.swift
@@ -57,6 +57,12 @@ struct AITranslateCommand: AsyncParsableCommand {
 
   @Flag(
     name: .long,
+    help: ArgumentHelp("Sort JSON keys to match Xcode's xcstrings ordering.")
+  )
+  var matchXcodeOrdering: Bool = false
+
+  @Flag(
+    name: .long,
     help: ArgumentHelp("Disable the rich terminal UI and use simple text output instead.")
   )
   var noTui: Bool = false
@@ -74,6 +80,7 @@ struct AITranslateCommand: AsyncParsableCommand {
       verbose: verbose,
       skipBackup: skipBackup,
       force: force,
+      matchXcodeOrdering: matchXcodeOrdering,
       reporter: reporter
     ).run()
   }

--- a/Sources/AITranslateLib/AITranslate.swift
+++ b/Sources/AITranslateLib/AITranslate.swift
@@ -45,6 +45,7 @@ public final class AITranslate: @unchecked Sendable {
   let verbose: Bool
   let skipBackup: Bool
   let force: Bool
+  let matchXcodeOrdering: Bool
   let reporter: ProgressReporter
 
   lazy var api: API = {
@@ -64,6 +65,7 @@ public final class AITranslate: @unchecked Sendable {
     verbose: Bool,
     skipBackup: Bool,
     force: Bool,
+    matchXcodeOrdering: Bool = false,
     reporter: ProgressReporter? = nil
   ) {
     self.inputFile = inputFile
@@ -72,6 +74,7 @@ public final class AITranslate: @unchecked Sendable {
     self.verbose = verbose
     self.skipBackup = skipBackup
     self.force = force
+    self.matchXcodeOrdering = matchXcodeOrdering
     self.reporter = reporter ?? SimpleProgressReporter()
   }
 
@@ -352,9 +355,20 @@ public final class AITranslate: @unchecked Sendable {
   }
 
   func save(_ catalog: StringCatalog) throws {
-    let encoder = JSONEncoder()
-    encoder.outputFormatting = [.sortedKeys, .prettyPrinted, .withoutEscapingSlashes]
-    let data = try encoder.encode(catalog)
+    let data: Data
+
+    if matchXcodeOrdering {
+      let encoded = try JSONEncoder().encode(catalog)
+      let jsonObject = try JSONSerialization.jsonObject(with: encoded)
+      data = try JSONSerialization.data(
+        withJSONObject: jsonObject,
+        options: [.sortedKeys, .prettyPrinted, .withoutEscapingSlashes]
+      )
+    } else {
+      let encoder = JSONEncoder()
+      encoder.outputFormatting = [.sortedKeys, .prettyPrinted, .withoutEscapingSlashes]
+      data = try encoder.encode(catalog)
+    }
 
     try backupInputFileIfNecessary()
     try data.write(to: inputFile)


### PR DESCRIPTION
## Summary
- Refactor into library + executable targets with tests
- Add concurrent batch translation (20 strings/batch, 5 batches in parallel) to reduce API usage ~20x
- Add rich terminal UI with live per-language progress panel (`--no-tui` to disable)
- Add `--match-xcode-ordering` flag to sort JSON keys using `JSONSerialization`, matching Xcode's xcstrings output
- Fix garbled verbose output from concurrent print calls
- Update README with current model name (GPT-5 mini) and all CLI flags

## Test plan
- [x] All 43 existing tests pass
- [ ] Run translation on a real xcstrings file with and without `--match-xcode-ordering`, verify output matches Xcode's format
- [ ] Verify `--no-tui` falls back to simple text output
- [ ] Test on a file with non-ASCII localization keys to confirm ordering matches Xcode